### PR TITLE
Fix package description

### DIFF
--- a/helm-flyspell.el
+++ b/helm-flyspell.el
@@ -1,4 +1,4 @@
-;;; helm-flyspell.el -- Helm extension for correcting words with flyspell
+;;; helm-flyspell.el --- Helm extension for correcting words with flyspell
 
 ;; Copyright (C) 2014 Andrzej Pronobis <a.pronobis@gmail.com>
 


### PR DESCRIPTION
Melpa shows "No description available" for `helm-flyspell`. This fixes the package description to match what is suggested at http://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html#Library-Headers.
