### PR TITLE
Fix package description

### DIFF
--- a/helm-flyspell.el
+++ b/helm-flyspell.el
@@ -1,4 +1,4 @@
-;;; helm-flyspell.el -- Helm extension for correcting words with flyspell  -*- lexical-binding: t; -*-
+;;; helm-flyspell.el --- Helm extension for correcting words with flyspell  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2014 Andrzej Pronobis <a.pronobis@gmail.com>
 


### PR DESCRIPTION
Fix the first line to match the excepted format:

```
;;; filename --- description
```

Without it, emacs can't identify the package description.

This is a repeat of 29ef48002d8e24f82ca5364c6a1315ffce20dcb2 which was lost in a merge (92d8fdc8fbc19aba8419e43bad18b8995cf25583).
